### PR TITLE
Alarms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ zephyr_library_sources(
   ${CMAKE_CURRENT_LIST_DIR}/src/program_logger.c
   ${CMAKE_CURRENT_LIST_DIR}/src/recipe.c
   ${CMAKE_CURRENT_LIST_DIR}/src/default_recipes.c
+  ${CMAKE_CURRENT_LIST_DIR}/src/alarm.c
   ${CMAKE_CURRENT_BINARY_DIR}/generated/parameters.c
   ${CMAKE_CURRENT_BINARY_DIR}/generated/default_recipes_generated.c
   )

--- a/include/koster-common/alarm.h
+++ b/include/koster-common/alarm.h
@@ -79,4 +79,14 @@ typedef int (*alarm_walk_cb_t)(const struct alarm_t alarm, void *arg);
  */
 int AlarmWalk(alarm_walk_cb_t cb, void *arg);
 
+/**
+ * @brief Test if an alarm is active
+ *
+ * @param[in] error_id  The error ID to test for
+ * @param[out] origin   Pointer to origin the will be set
+
+ * @return true if the error is active, false if not.
+ */
+bool AlarmIsActive(const uint8_t error_id, alarm_origin_t *origin);
+
 #endif

--- a/include/koster-common/alarm.h
+++ b/include/koster-common/alarm.h
@@ -15,8 +15,6 @@ typedef enum {
     kAlarmOriginVinga3 = 0x2200,
     kAlarmOriginVinga4 = 0x2300,
     kAlarmOriginVinga5 = 0x2400,
-    kAlarmOriginTest1 = 0xF000,
-    kAlarmOriginTest2 = 0xF100,
 } alarm_origin_t;
 
 struct alarm_t {

--- a/include/koster-common/alarm.h
+++ b/include/koster-common/alarm.h
@@ -1,14 +1,82 @@
 #ifndef KOSTER_COMMON_ALARM_H
 #define KOSTER_COMMON_ALARM_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
-#define ALARM_ORIGIN_MASK 0xF000
-#define ALARM_ORIGIN_DETAIL_MASK 0x0F00
+#define ALARM_ORIGIN_MASK 0xFF00
 #define ALARM_ERROR_ID_MASK 0x00FF
 
-typedef enum { kAlarmOriginUnknown = 0, kAlarmOriginKoster = 0x1000, kAlarmOriginVinga = 0x2000 } alarm_origin_t;
+typedef enum {
+    kAlarmOriginUnknown = 0,
+    kAlarmOriginKoster = 0x1000,
+    kAlarmOriginVinga1 = 0x2000,
+    kAlarmOriginVinga2 = 0x2100,
+    kAlarmOriginVinga3 = 0x2200,
+    kAlarmOriginVinga4 = 0x2300,
+    kAlarmOriginVinga5 = 0x2400,
+    kAlarmOriginTest1 = 0xF000,
+    kAlarmOriginTest2 = 0xF100,
+} alarm_origin_t;
 
+struct alarm_t {
+    uint16_t id;
+    uint32_t epoch;  // milliseconds
+};
+
+/**
+ * @brief Initialize alarm handler
+ */
+void AlarmInit();
+
+/**
+ * @brief Get type for alarm.
+ *
+ * @param alarm_id the alarm ID (origin | error_id)
+ * @return the alarm type 'A', 'B', or 'U' (Unknown).
+ */
 char AlarmGetType(uint16_t alarm_id);
+
+/**
+ * @brief Set or clear an alarm alarm.
+ *
+ * @param active  true to activate the alarm, false to clear
+ * @param error_id  the error ID (alarm ID sans origin)
+ * @param origin  the origin (alarm ID sans error ID)
+ * @return 0 on success, -1 on error
+ */
+int AlarmSet(const bool active, const uint8_t error_id, const alarm_origin_t origin);
+
+/**
+ * @brief Check if there are active type A alarms (critical)
+ *
+ * @return true if there are type A alarms active, false if not
+ */
+bool AlarmActiveTypeAAlarms();
+
+/**
+ * @brief Callback function type for active alarm entries.
+ *
+ * This function is called for each alarm entry during iteration in AlarmWalk.
+ *
+ * @param entry Pointer to the current alarm id.
+ * @param arg   User-defined argument passed from input to AlarmWalk
+ *
+ * @return 0 to continue iteration, non-zero to stop.
+ */
+typedef int (*alarm_walk_cb_t)(const struct alarm_t alarm, void *arg);
+
+/**
+ * @brief Iterates over each active alarm entry and invokes the provided callback function.
+ *
+ * @param cb Pointer to a function to be called for each entry
+ * @param arg Pointer to user-defined data to be passed to the callback function.
+ *
+ * @details The function processes all entries, calling the callback for each one if provided.
+ *          If the callback returns a non-zero value, the iteration stops early.
+ *
+ * @return 0 on success, -1 if the walk failed or was stopped by callback.
+ */
+int AlarmWalk(alarm_walk_cb_t cb, void *arg);
 
 #endif

--- a/include/koster-common/alarm.h
+++ b/include/koster-common/alarm.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #define ALARM_ORIGIN_MASK 0xF000
-#define ALARM_BOARD_NUMBER_MASK 0x0F00
+#define ALARM_ORIGIN_DETAIL_MASK 0x0F00
 #define ALARM_ERROR_ID_MASK 0x00FF
 
 typedef enum { kAlarmOriginUnknown = 0, kAlarmOriginKoster = 0x1000, kAlarmOriginVinga = 0x2000 } alarm_origin_t;

--- a/include/koster-common/alarm.h
+++ b/include/koster-common/alarm.h
@@ -1,0 +1,14 @@
+#ifndef KOSTER_COMMON_ALARM_H
+#define KOSTER_COMMON_ALARM_H
+
+#include <stdint.h>
+
+#define ALARM_ORIGIN_MASK 0xF000
+#define ALARM_BOARD_NUMBER_MASK 0x0F00
+#define ALARM_ERROR_ID_MASK 0x00FF
+
+typedef enum { kAlarmOriginUnknown = 0, kAlarmOriginKoster = 0x1000, kAlarmOriginVinga = 0x2000 } alarm_origin_t;
+
+char AlarmGetType(uint16_t alarm_id);
+
+#endif

--- a/include/koster-common/koster-zbus.h
+++ b/include/koster-common/koster-zbus.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <zephyr/zbus/zbus.h>
 
+#include "koster-common/alarm.h"
+
 #define ZBUS_SENDER_NAME_MAX_LEN 16
 
 /**
@@ -89,16 +91,12 @@ struct kzbus_distance_msg_t {
     uint8_t vinga_id;
 };
 
-typedef enum { kRunnerErrorNone, kRunnerErrorA, kRunnerErrorB } runner_error_t;
-
 /**
- * Sent from the Runner. Sent on channel kzbus_error_chan.
+ * Sent from the Runner. Sent on channel kzbus_alarm_chan.
  */
-struct kzbus_error_msg_t {
-    runner_error_t error_type;
-    uint8_t error_id;
-    /** the ID of the Vinga node the error originated from  */
-    uint8_t vinga_id;
+struct kzbus_alarm_msg_t {
+    bool alarm_active;
+    uint16_t alarm_id;
 };
 
 /**
@@ -124,7 +122,7 @@ typedef enum {
     kMsgTemperature,
     kMsgDistance,
     kMsgIRCamera,
-    kMsgError
+    kMsgAlarm
 } kzbus_msg_type_t;
 
 /**
@@ -145,7 +143,7 @@ struct kzbus_msg_t {
         struct kzbus_program_msg_t program_msg;
         struct kzbus_temperature_msg_t temperature_msg;
         struct kzbus_distance_msg_t distance_msg;
-        struct kzbus_error_msg_t error_msg;
+        struct kzbus_alarm_msg_t alarm_msg;
         struct kzbus_ircam_msg_t ircam_msg;
     };
 };
@@ -159,7 +157,7 @@ struct kzbus_msg_t {
 ZBUS_CHAN_DECLARE(kzbus_program_chan,      // Channel for program state messages (from program runner)
                   kzbus_temperature_chan,  // Channel for temperature messages (from program runner)
                   kzbus_distance_chan,     // Channel for distance messages (from program runner)
-                  kzbus_error_chan,        // Channel for error messages (from program runner)
+                  kzbus_alarm_chan,        // Channel for alarm messages (from program runner)
                   kzbus_control_chan,      // Channel for control messages (to program runner)
                   kzbus_ircam_chan         // Channel for IR camera (from program runner)
 );

--- a/include/koster-common/koster-zbus.h
+++ b/include/koster-common/koster-zbus.h
@@ -89,7 +89,7 @@ struct kzbus_distance_msg_t {
     uint8_t vinga_id;
 };
 
-typedef enum { kRunnerErrorA, kRunnerErrorB } runner_error_t;
+typedef enum { kRunnerErrorNone, kRunnerErrorA, kRunnerErrorB } runner_error_t;
 
 /**
  * Sent from the Runner. Sent on channel kzbus_error_chan.

--- a/include/koster-common/program_history.h
+++ b/include/koster-common/program_history.h
@@ -63,7 +63,7 @@ struct program_data_v1_t {
     int16_t img[PROGRAM_HISTORY_IMG_DATA_SIZE_V1];
     uint8_t param_ids[PROGRAM_HISTORY_MAX_PARAMS_V1];
     int32_t param_vals[PROGRAM_HISTORY_MAX_PARAMS_V1];
-    uint8_t alarm_ids[PROGRAM_HISTORY_MAX_ALARMS_V1];
+    uint16_t alarm_ids[PROGRAM_HISTORY_MAX_ALARMS_V1];
 };
 
 struct program_header_t {

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -14,13 +14,11 @@ LOG_MODULE_DECLARE(koster_common);
 struct k_mutex alarm_mutex_;
 static uint16_t active_alarms_[ALARM_MAX_ALARMS];
 static uint32_t active_alarm_times_[ALARM_MAX_ALARMS];
-static int number_of_active_alarms_;
 
 extern const struct zbus_channel kzbus_alarm_chan;
 
 void AlarmInit() {
     k_mutex_init(&alarm_mutex_);
-    number_of_active_alarms_ = 0;
     memset(active_alarms_, 0, sizeof(active_alarms_));
     memset(active_alarm_times_, 0, sizeof(active_alarm_times_));
 }
@@ -40,7 +38,6 @@ char AlarmGetType(uint16_t alarm_id) {
         case 0x1012:
         case 0x1013:
         case 0x1014:
-        case 0xF001:
             return 'A';
         case 0x1001:
         case 0x1004:
@@ -52,7 +49,6 @@ char AlarmGetType(uint16_t alarm_id) {
         case 0x1015:
         case 0x1016:
         case 0x1017:
-        case 0xF102:
             return 'B';
         default:
             return 'U';
@@ -88,7 +84,6 @@ int AlarmSet(const bool active, const uint8_t error_id, const alarm_origin_t ori
                     LOG_INF("[alarm] Clearing alarm ID 0x%X", alarm_id);
                     active_alarms_[i] = 0;
                     active_alarm_times_[i] = 0;
-                    number_of_active_alarms_--;
                     notify = true;
                     rc = 0;
                     break;
@@ -98,7 +93,6 @@ int AlarmSet(const bool active, const uint8_t error_id, const alarm_origin_t ori
 
         if (first_free_index < ALARM_MAX_ALARMS && active) {
             LOG_ERR("[alarm] Setting alarm ID 0x%X", alarm_id);
-            number_of_active_alarms_++;
             active_alarms_[first_free_index] = alarm_id;
             active_alarm_times_[first_free_index] = epoch;
             notify = true;

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -1,7 +1,8 @@
 #include "koster-common/alarm.h"
 
+#include <memory.h>
+#include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/sys/atomic.h>
 #include <zephyr/zbus/zbus.h>
 
 #include "koster-common/koster-zbus.h"
@@ -10,16 +11,18 @@ LOG_MODULE_DECLARE(koster_common);
 
 #define ALARM_MAX_ALARMS 20
 
-static atomic_t active_alarms_[ALARM_MAX_ALARMS];
-static atomic_t active_alarm_times_[ALARM_MAX_ALARMS];
-static atomic_t number_of_active_alarms_;
+struct k_mutex alarm_mutex_;
+static uint16_t active_alarms_[ALARM_MAX_ALARMS];
+static uint32_t active_alarm_times_[ALARM_MAX_ALARMS];
+static int number_of_active_alarms_;
+
+extern const struct zbus_channel kzbus_alarm_chan;
 
 void AlarmInit() {
-    number_of_active_alarms_ = ATOMIC_INIT(0);
-    for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
-        active_alarms_[i] = ATOMIC_INIT(0);
-        active_alarm_times_[i] = ATOMIC_INIT(0);
-    }
+    k_mutex_init(&alarm_mutex_);
+    number_of_active_alarms_ = 0;
+    memset(active_alarms_, 0, sizeof(active_alarms_));
+    memset(active_alarm_times_, 0, sizeof(active_alarm_times_));
 }
 
 char AlarmGetType(uint16_t alarm_id) {
@@ -70,57 +73,93 @@ int AlarmSet(const bool active, const uint8_t error_id, const alarm_origin_t ori
     const uint16_t alarm_id = (((uint16_t)error_id) & ALARM_ERROR_ID_MASK) | (origin & ALARM_ORIGIN_MASK);
     int rc = -1;
     uint32_t first_free_index = UINT32_MAX;
+    bool notify = false;
+#warning "TODO: Use RTC"
     const uint32_t epoch = k_uptime_seconds();
-    for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
-        const uint16_t alarm_id_i = (uint16_t)(atomic_get(&active_alarms_[i]) & 0xFFFF);
-        if (alarm_id_i == 0 && first_free_index == UINT32_MAX) {
-            first_free_index = i;
-        }
-        if (alarm_id_i == alarm_id) {
-            if (!active) {
-                LOG_INF("[alarm] Clearing alarm ID 0x%X", alarm_id);
-                atomic_inc(&number_of_active_alarms_);
-                atomic_clear(&active_alarms_[i]);
-                atomic_clear(&active_alarm_times_[i]);
-                notify_alarm(active, alarm_id, epoch);
-                rc = 0;
-                break;
+
+    if (k_mutex_lock(&alarm_mutex_, K_FOREVER) == 0) {
+        for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
+            const uint16_t alarm_id_i = active_alarms_[i];
+            if (alarm_id_i == 0 && first_free_index == UINT32_MAX) {
+                first_free_index = i;
+            }
+            if (alarm_id_i == alarm_id) {
+                if (!active) {
+                    LOG_INF("[alarm] Clearing alarm ID 0x%X", alarm_id);
+                    active_alarms_[i] = 0;
+                    active_alarm_times_[i] = 0;
+                    number_of_active_alarms_--;
+                    notify = true;
+                    rc = 0;
+                    break;
+                }
             }
         }
+
+        if (first_free_index < ALARM_MAX_ALARMS && active) {
+            LOG_ERR("[alarm] Setting alarm ID 0x%X", alarm_id);
+            number_of_active_alarms_++;
+            active_alarms_[first_free_index] = alarm_id;
+            active_alarm_times_[first_free_index] = epoch;
+            notify = true;
+            rc = 0;
+        }
+
+        k_mutex_unlock(&alarm_mutex_);
     }
 
-    if (first_free_index < ALARM_MAX_ALARMS) {
-        LOG_ERR("[alarm] Setting alarm ID 0x%X", alarm_id);
-        atomic_dec(&number_of_active_alarms_);
-        atomic_set(&active_alarms_[first_free_index], alarm_id);
-        atomic_set(&active_alarm_times_[first_free_index], epoch);
+    if (notify) {
         notify_alarm(active, alarm_id, epoch);
-        rc = 0;
     }
 
     return rc;
 }
 
 bool AlarmActiveTypeAAlarms() {
-    for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
-        if (AlarmGetType(atomic_get(&active_alarms_[i])) == 'A') {
-            return true;
+    bool ret = false;
+    if (k_mutex_lock(&alarm_mutex_, K_FOREVER) == 0) {
+        for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
+            if (AlarmGetType(active_alarms_[i]) == 'A') {
+                ret = true;
+                break;
+            }
         }
+        k_mutex_unlock(&alarm_mutex_);
     }
-    return false;
+    return ret;
 }
 
 int AlarmWalk(alarm_walk_cb_t cb, void *arg) {
     int rc = 0;
-    for (int i = 0; i < ALARM_MAX_ALARMS && rc == 0; ++i) {
-        struct alarm_t alarm;
-        alarm.id = (uint16_t)(atomic_get(&active_alarms_[i]) & 0xFFFF);
-        if (alarm.id == 0) {
-            continue;
-        }
-        alarm.epoch = (uint16_t)(atomic_get(&active_alarm_times_[i]) & 0xFFFF);
+    if (k_mutex_lock(&alarm_mutex_, K_FOREVER) == 0) {
+        for (int i = 0; i < ALARM_MAX_ALARMS && rc == 0; ++i) {
+            struct alarm_t alarm;
+            alarm.id = active_alarms_[i];
+            if (alarm.id == 0) {
+                continue;
+            }
+            alarm.epoch = active_alarm_times_[i];
 
-        rc = cb(alarm, arg);
+            rc = cb(alarm, arg);
+        }
+        k_mutex_unlock(&alarm_mutex_);
     }
     return rc;
+}
+
+bool AlarmIsActive(const uint8_t error_id, alarm_origin_t *origin) {
+    bool is_active = false;
+    if (k_mutex_lock(&alarm_mutex_, K_FOREVER) == 0) {
+        for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
+            if ((active_alarms_[i] & ALARM_ERROR_ID_MASK) == error_id) {
+                is_active = true;
+                if (origin != NULL) {
+                    *origin = active_alarms_[i] & ALARM_ORIGIN_MASK;
+                }
+                break;
+            }
+        }
+        k_mutex_unlock(&alarm_mutex_);
+    }
+    return is_active;
 }

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -1,0 +1,9 @@
+#include "koster-common/alarm.h"
+
+char AlarmGetType(uint16_t alarm_id) {
+    switch (alarm_id & ALARM_ERROR_ID_MASK) {
+        default:
+            return 'X';
+    }
+    return 'X';
+}

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -1,9 +1,126 @@
 #include "koster-common/alarm.h"
 
-char AlarmGetType(uint16_t alarm_id) {
-    switch (alarm_id & ALARM_ERROR_ID_MASK) {
-        default:
-            return 'X';
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/zbus/zbus.h>
+
+#include "koster-common/koster-zbus.h"
+
+LOG_MODULE_DECLARE(koster_common);
+
+#define ALARM_MAX_ALARMS 20
+
+static atomic_t active_alarms_[ALARM_MAX_ALARMS];
+static atomic_t active_alarm_times_[ALARM_MAX_ALARMS];
+static atomic_t number_of_active_alarms_;
+
+void AlarmInit() {
+    number_of_active_alarms_ = ATOMIC_INIT(0);
+    for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
+        active_alarms_[i] = ATOMIC_INIT(0);
+        active_alarm_times_[i] = ATOMIC_INIT(0);
     }
-    return 'X';
+}
+
+char AlarmGetType(uint16_t alarm_id) {
+    switch (alarm_id) {
+        case 0x1002:
+        case 0x1003:
+        case 0x1008:
+        case 0x1009:
+        case 0x100A:
+        case 0x100B:
+        case 0x100C:
+        case 0x100D:
+        case 0x100F:
+        case 0x1011:
+        case 0x1012:
+        case 0x1013:
+        case 0x1014:
+        case 0xF001:
+            return 'A';
+        case 0x1001:
+        case 0x1004:
+        case 0x1005:
+        case 0x1006:
+        case 0x1007:
+        case 0x100E:
+        case 0x1010:
+        case 0x1015:
+        case 0x1016:
+        case 0x1017:
+        case 0xF102:
+            return 'B';
+        default:
+            return 'U';
+    }
+    return 'U';
+}
+
+static void notify_alarm(const bool active, const uint16_t alarm_id, const uint32_t epoch) {
+    struct kzbus_msg_t alarm_msg;
+    alarm_msg.msg_type = kMsgAlarm;
+    alarm_msg.epoch_time = epoch;
+    alarm_msg.alarm_msg.alarm_active = active;
+    alarm_msg.alarm_msg.alarm_id = alarm_id;
+    zbus_chan_pub(&kzbus_alarm_chan, &alarm_msg, K_NO_WAIT);
+}
+
+int AlarmSet(const bool active, const uint8_t error_id, const alarm_origin_t origin) {
+    const uint16_t alarm_id = (((uint16_t)error_id) & ALARM_ERROR_ID_MASK) | (origin & ALARM_ORIGIN_MASK);
+    int rc = -1;
+    uint32_t first_free_index = UINT32_MAX;
+    const uint32_t epoch = k_uptime_seconds();
+    for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
+        const uint16_t alarm_id_i = (uint16_t)(atomic_get(&active_alarms_[i]) & 0xFFFF);
+        if (alarm_id_i == 0 && first_free_index == UINT32_MAX) {
+            first_free_index = i;
+        }
+        if (alarm_id_i == alarm_id) {
+            if (!active) {
+                LOG_INF("[alarm] Clearing alarm ID 0x%X", alarm_id);
+                atomic_inc(&number_of_active_alarms_);
+                atomic_clear(&active_alarms_[i]);
+                atomic_clear(&active_alarm_times_[i]);
+                notify_alarm(active, alarm_id, epoch);
+                rc = 0;
+                break;
+            }
+        }
+    }
+
+    if (first_free_index < ALARM_MAX_ALARMS) {
+        LOG_ERR("[alarm] Setting alarm ID 0x%X", alarm_id);
+        atomic_dec(&number_of_active_alarms_);
+        atomic_set(&active_alarms_[first_free_index], alarm_id);
+        atomic_set(&active_alarm_times_[first_free_index], epoch);
+        notify_alarm(active, alarm_id, epoch);
+        rc = 0;
+    }
+
+    return rc;
+}
+
+bool AlarmActiveTypeAAlarms() {
+    for (int i = 0; i < ALARM_MAX_ALARMS; ++i) {
+        if (AlarmGetType(atomic_get(&active_alarms_[i])) == 'A') {
+            return true;
+        }
+    }
+    return false;
+}
+
+int AlarmWalk(alarm_walk_cb_t cb, void *arg) {
+    int rc = 0;
+    for (int i = 0; i < ALARM_MAX_ALARMS && rc == 0; ++i) {
+        struct alarm_t alarm;
+        alarm.id = (uint16_t)(atomic_get(&active_alarms_[i]) & 0xFFFF);
+        if (alarm.id == 0) {
+            continue;
+        }
+        alarm.epoch = (uint16_t)(atomic_get(&active_alarm_times_[i]) & 0xFFFF);
+
+        rc = cb(alarm, arg);
+    }
+    return rc;
 }

--- a/src/koster-zbus.c
+++ b/src/koster-zbus.c
@@ -31,23 +31,23 @@ ZBUS_CHAN_DEFINE(kzbus_distance_chan, /* Name */
                  ZBUS_MSG_INIT(0));
 
 /**
- * Channel for error messages (from program runner)
+ * Channel for alarm messages (from program runner)
  */
-ZBUS_CHAN_DEFINE(kzbus_error_chan,              /* Name */
-                 struct kzbus_msg_t,            /* Message type */
-                 NULL,                          /* Validator */
-                 NULL,                          /* User data */
-                 ZBUS_OBSERVERS(),              /* Observers */
+ZBUS_CHAN_DEFINE(kzbus_alarm_chan,   /* Name */
+                 struct kzbus_msg_t, /* Message type */
+                 NULL,               /* Validator */
+                 NULL,               /* User data */
+                 ZBUS_OBSERVERS(),   /* Observers */
                  ZBUS_MSG_INIT(0));
 
 /**
  * Channel for IR camera image buffer (from program runner)
  */
-ZBUS_CHAN_DEFINE(kzbus_ircam_chan,              /* Name */
-                 struct kzbus_msg_t,            /* Message type */
-                 NULL,                          /* Validator */
-                 NULL,                          /* User data */
-                 ZBUS_OBSERVERS(),              /* Observers */
+ZBUS_CHAN_DEFINE(kzbus_ircam_chan,   /* Name */
+                 struct kzbus_msg_t, /* Message type */
+                 NULL,               /* Validator */
+                 NULL,               /* User data */
+                 ZBUS_OBSERVERS(),   /* Observers */
                  ZBUS_MSG_INIT(0));
 
 /**

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ include(GoogleTest)
 add_library(zephyr-mocks
   ${CMAKE_CURRENT_LIST_DIR}/include/zephyr/kernel.c
   ${CMAKE_CURRENT_LIST_DIR}/include/zephyr/settings/settings.c
+  ${CMAKE_CURRENT_LIST_DIR}/include/zephyr/zbus/zbus.c
   )
 target_include_directories(zephyr-mocks PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}/include
@@ -27,3 +28,4 @@ enable_testing()
 add_subdirectory(default_recipes)
 add_subdirectory(parameters)
 add_subdirectory(recipe)
+add_subdirectory(alarm)

--- a/tests/unit/alarm/CMakeLists.txt
+++ b/tests/unit/alarm/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(TEST_NAME alarm_tests)
+
+# Generated files
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../cmake)
+
+add_executable(${TEST_NAME}
+  ${CMAKE_CURRENT_LIST_DIR}/alarm_tests.cpp
+  ${PROJECT_SOURCE_DIR}/../../src/alarm.c
+)
+
+target_include_directories(${TEST_NAME} PRIVATE
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/../../include
+  ${PROJECT_SOURCE_DIR}/../../src
+)
+
+target_link_libraries(${TEST_NAME}
+  GTest::gmock_main
+  zephyr-mocks
+)
+
+include(GoogleTest)
+gtest_discover_tests(${TEST_NAME})

--- a/tests/unit/alarm/alarm_tests.cpp
+++ b/tests/unit/alarm/alarm_tests.cpp
@@ -1,0 +1,113 @@
+#include <vector>
+
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "fff/fff.h"
+#include "koster-common/alarm.h"
+#include "zephyr/zbus/zbus.h"
+}
+
+DEFINE_FFF_GLOBALS;
+
+const struct zbus_channel kzbus_alarm_chan;
+
+constexpr uint8_t kTypeAAlarmId{1};
+constexpr alarm_origin_t kTypeAAlarmOrigin{kAlarmOriginTest1};
+constexpr int kAlarmMaxAlarms{20};
+
+std::vector<alarm_t> alarm_walk_entries_;
+int walk_callback(const alarm_t alarm, void*) {
+    alarm_walk_entries_.push_back(alarm);
+    return 0;
+}
+
+class AlarmTests : public testing::Test {
+  protected:
+    void SetUp() override {
+        AlarmInit();
+        alarm_walk_entries_.clear();
+    };
+};
+
+TEST_F(AlarmTests, TypeAAlarmNotActive_AlarmActiveTypeAAlarmsReturnsFalse) { ASSERT_FALSE(AlarmActiveTypeAAlarms()); }
+
+TEST_F(AlarmTests, TypeAAlarmActive_AlarmActiveTypeAAlarmsReturnsTrue) {
+    ASSERT_EQ(AlarmSet(true, kTypeAAlarmId, kTypeAAlarmOrigin), 0);
+    ASSERT_TRUE(AlarmActiveTypeAAlarms());
+}
+
+TEST_F(AlarmTests, AlarmSet_ReturnNegativeWhenMaxIsReached) {
+    for (int i = 0; i < kAlarmMaxAlarms; ++i) {
+        ASSERT_EQ(AlarmSet(true, i, kAlarmOriginTest1), 0);
+    }
+    ASSERT_LT(AlarmSet(true, kAlarmMaxAlarms, kAlarmOriginTest1), 0);
+}
+
+TEST_F(AlarmTests, AlarmSetAFewEntriesAndWalk) {
+    ASSERT_EQ(AlarmSet(true, 1, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 2, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 3, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmWalk(walk_callback, NULL), 0);
+    ASSERT_EQ(alarm_walk_entries_.size(), 3);
+    ASSERT_EQ(alarm_walk_entries_.at(0).id, 1 | kAlarmOriginTest1);
+    ASSERT_EQ(alarm_walk_entries_.at(1).id, 2 | kAlarmOriginTest1);
+    ASSERT_EQ(alarm_walk_entries_.at(2).id, 3 | kAlarmOriginTest1);
+}
+
+TEST_F(AlarmTests, AlarmSetAndClearAFewEntriesAndWalk) {
+    ASSERT_EQ(AlarmSet(true, 1, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 2, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 3, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 4, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 5, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(false, 2, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(false, 4, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmWalk(walk_callback, NULL), 0);
+    ASSERT_EQ(alarm_walk_entries_.size(), 3);
+    ASSERT_EQ(alarm_walk_entries_.at(0).id, 1 | kAlarmOriginTest1);
+    ASSERT_EQ(alarm_walk_entries_.at(1).id, 3 | kAlarmOriginTest1);
+    ASSERT_EQ(alarm_walk_entries_.at(2).id, 5 | kAlarmOriginTest1);
+}
+
+TEST_F(AlarmTests, AlarmSet_AlarmIsActiveReturnsTrue) {
+    ASSERT_EQ(AlarmSet(true, 1, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 2, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 3, kAlarmOriginTest2), 0);
+
+    alarm_origin_t origin;
+    ASSERT_TRUE(AlarmIsActive(1, &origin));
+    ASSERT_EQ(origin, kAlarmOriginTest1);
+
+    ASSERT_TRUE(AlarmIsActive(2, &origin));
+    ASSERT_EQ(origin, kAlarmOriginTest1);
+
+    ASSERT_TRUE(AlarmIsActive(3, &origin));
+    ASSERT_EQ(origin, kAlarmOriginTest2);
+
+    ASSERT_FALSE(AlarmIsActive(4, NULL));
+}
+
+TEST_F(AlarmTests, AlarmSetAndClearAFewEntries_AlarmIsActiveReturnsCorrect) {
+    ASSERT_EQ(AlarmSet(true, 1, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 2, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 3, kAlarmOriginTest2), 0);
+    ASSERT_EQ(AlarmSet(true, 4, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(true, 5, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(false, 2, kAlarmOriginTest1), 0);
+    ASSERT_EQ(AlarmSet(false, 4, kAlarmOriginTest1), 0);
+
+    alarm_origin_t origin;
+    ASSERT_TRUE(AlarmIsActive(1, &origin));
+    ASSERT_EQ(origin, kAlarmOriginTest1);
+
+    ASSERT_FALSE(AlarmIsActive(2, &origin));
+
+    ASSERT_TRUE(AlarmIsActive(3, &origin));
+    ASSERT_EQ(origin, kAlarmOriginTest2);
+
+    ASSERT_FALSE(AlarmIsActive(4, &origin));
+
+    ASSERT_TRUE(AlarmIsActive(5, &origin));
+    ASSERT_EQ(origin, kAlarmOriginTest1);
+}

--- a/tests/unit/include/zephyr/kernel.c
+++ b/tests/unit/include/zephyr/kernel.c
@@ -7,3 +7,5 @@ DEFINE_FAKE_VALUE_FUNC(int, k_mutex_init, struct k_mutex *);
 DEFINE_FAKE_VALUE_FUNC(int, settings_name_next, const char *, const char **);
 DEFINE_FAKE_VOID_FUNC(z_log_minimal_printk);
 DEFINE_FAKE_VOID_FUNC(log_const_app);
+
+DEFINE_FAKE_VALUE_FUNC(uint32_t, k_uptime_seconds);

--- a/tests/unit/include/zephyr/kernel.h
+++ b/tests/unit/include/zephyr/kernel.h
@@ -8,6 +8,7 @@
 #define K_MSEC(X) X
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define K_FOREVER 0
+#define K_NO_WAIT 0
 
 struct k_mutex {
     int foo;
@@ -21,3 +22,5 @@ DECLARE_FAKE_VALUE_FUNC(int, k_mutex_init, struct k_mutex *);
 DECLARE_FAKE_VALUE_FUNC(int, settings_name_next, const char *, const char **);
 DECLARE_FAKE_VOID_FUNC(z_log_minimal_printk);
 DECLARE_FAKE_VOID_FUNC(log_const_app);
+
+DECLARE_FAKE_VALUE_FUNC(uint32_t, k_uptime_seconds);

--- a/tests/unit/include/zephyr/zbus/zbus.c
+++ b/tests/unit/include/zephyr/zbus/zbus.c
@@ -1,0 +1,3 @@
+#include "zephyr/zbus/zbus.h"
+
+DEFINE_FAKE_VALUE_FUNC(int, zbus_chan_pub, const struct zbus_channel *, const void *, k_timeout_t);

--- a/tests/unit/include/zephyr/zbus/zbus.h
+++ b/tests/unit/include/zephyr/zbus/zbus.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "fff/fff.h"
+#include "zephyr/kernel.h"
+
+struct zbus_channel {};
+
+#define ZBUS_CHAN_DECLARE(_name, ...) struct zbus_channel _name
+
+DECLARE_FAKE_VALUE_FUNC(int, zbus_chan_pub, const struct zbus_channel *, const void *, k_timeout_t);


### PR DESCRIPTION
- Changed the ZBus message and channel for alarms.
- My idea is that an alarm ID is a uint16_t where 
   - the high nibble is the "origin", e.g. a board (Koster/vinga)
   - the the second-highest nibble is details of the origin, e.g. Vinga number or STM32/EPS32 on Koster
   - the low byte is the error ID