### PR TITLE
Add program state Starting

### DIFF
--- a/include/koster-common/koster-zbus.h
+++ b/include/koster-common/koster-zbus.h
@@ -39,6 +39,8 @@ struct kzbus_req_laser_off_msg_t {};
 typedef enum {
     /** No program is running */
     kProgramStateIdle,
+    /** A program is starting */
+    kProgramStateStarting,
     /** A program is running */
     kProgramStateRunning,
     /** An error occured */


### PR DESCRIPTION
Added a state that the runner can send when a program is just starting. It makes it easier for the UI to set the timer strings correctly and to determine when a program has finished.